### PR TITLE
Make Makefile auth-agnostic + persist provider cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,10 @@ include $(PROJECT_PATH)/Makefile.*
 # main
 export UNAME_S ?= $(shell uname -s)
 
+# Skip the AWS_PROFILE default when aws-vault has provided credential env vars.
+ifndef AWS_ACCESS_KEY_ID
 export AWS_PROFILE ?= unknown
+endif
 export AWS_DEFAULT_REGION ?= us-west-2
 export REPO_NAME := $(shell basename ${PWD})
 
@@ -26,9 +29,16 @@ DOCKER_ARGS += --tty
 DOCKER_ARGS += --rm
 DOCKER_ARGS += --env AWS_PROFILE --env AWS_DEFAULT_REGION
 DOCKER_ARGS += --env REPO_NAME
+# Credential env vars (set by aws-vault). Forwarded only when present; when they
+# are absent the container falls back to AWS_PROFILE + the mounted ~/.aws, so
+# `make dev` works with or without aws-vault.
+DOCKER_ARGS += --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY
+DOCKER_ARGS += --env AWS_SESSION_TOKEN --env AWS_REGION
 DOCKER_ARGS += --workdir /app
 DOCKER_ARGS += --volume ${PWD}:/app
 DOCKER_ARGS += --volume ${HOME}/.aws:/root/.aws
+# Persist the provider cache (image's .terraformrc plugin_cache_dir) across runs.
+DOCKER_ARGS += --volume ${HOME}/.terraform.d/plugin-cache:/opt/terraform/plugin-cache
 DOCKER_ARGS += --volume ${HOME}/.ssh/known_hosts:/root/.ssh/known_hosts
 DOCKER_ARGS += --volume ${HOME}/.gitconfig:/root/.gitconfig:ro
 DOCKER_ARGS += --pull $(DOCKER_PULL)


### PR DESCRIPTION
Backports three generic Makefile improvements (found while wiring a repo made from this template):

- **Forward aws-vault credential env vars** into the dev container, so `make dev` authenticates via aws-vault.
- **Gate the `AWS_PROFILE=unknown` default** behind `ifndef AWS_ACCESS_KEY_ID` — the bogus default made the AWS CLI fail on a nonexistent profile even when aws-vault had valid creds. Now aws-vault creds win, file-based `AWS_PROFILE=<name>` still works, and a bare `make dev` with no auth still fails loudly.
- **Persist the provider cache** by mounting a host dir onto the image's `plugin_cache_dir`, so providers download once instead of every `--rm` run.

Makefile-only; no deployment/module changes.