### PR TITLE
ci: grant actions:read for Slack status on private repos

### DIFF
--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -14,6 +14,11 @@ env:
   TG_WORKING_DIR: './deployments'
   TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
 
+# Private repos need actions:read for the Slack status action to query the run.
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   format:
     name: Format


### PR DESCRIPTION
The template's `terragrunt.yml` Slack step (`Gamesight/slack-workflow-status`) queries the Actions API for run status. On **private** repos created from this template, the restricted default `GITHUB_TOKEN` lacks `actions:read`, so the step fails with *Resource not accessible by integration*. Public repos are unaffected.

Adds a workflow-level `permissions` block requesting `contents:read` + `actions:read`. Verified on `terragrunt-aws-minecraft` (private) — pipeline goes green.