### PR TITLE
chore: align renovate config with terraform-aws-module-template

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,13 +1,15 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":preserveSemverRanges"
   ],
   "labels": [
     "auto-update"
   ],
   "enabledManagers": [
-    "terraform"
+    "terraform",
+    "github-actions"
   ],
   "terraform": {
     "ignorePaths": [


### PR DESCRIPTION
Aligns this repo's `.github/renovate.json` with the newer config in `terraform-aws-module-template`.

## Changes
- Add `\$schema` for editor validation
- Switch `config:base` → `config:recommended` (current preset name; `config:base` is a deprecated alias)
- Enable the `github-actions` manager so Renovate also keeps workflow actions up to date

`terraform.ignorePaths` (`context.tf`, `examples/**`) were already aligned and left unchanged. The two configs are now identical.