### PR TITLE
ci: deploy via GitHub OIDC hub trust model

### DIFF
--- a/.github/actions/aws-auth/action.yml
+++ b/.github/actions/aws-auth/action.yml
@@ -1,0 +1,67 @@
+---
+name: AWS auth (hub -> deploy role)
+description: >-
+  Authenticate to the target account via the hub trust model: OIDC into the
+  management-account TerraformRunnerRole, resolve the account id from AWS
+  Organizations by name (no committed account map), then role-chain into that
+  account's TerraformDeploymentRole. Leaves deploy credentials in the job env
+  for subsequent steps.
+
+inputs:
+  runner-role-arn:
+    description: ARN of the hub TerraformRunnerRole in the management account.
+    required: true
+  account-name:
+    description: >-
+      AWS Organizations account name to deploy into (e.g. "myorg-sandbox").
+      Resolved to an account id via organizations:ListAccounts.
+    required: true
+  deploy-role-path:
+    description: Path + name of the per-account deploy role to chain into.
+    required: false
+    default: Org/TerraformDeploymentRole
+  aws-region:
+    description: Region for the AWS SDK/CLI.
+    required: false
+    default: us-west-2
+
+runs:
+  using: composite
+  steps:
+    # Hop 1: exchange the GitHub OIDC token for the hub runner role.
+    - name: Assume hub runner role (OIDC)
+      uses: aws-actions/configure-aws-credentials@v5
+      with:
+        role-to-assume: ${{ inputs.runner-role-arn }}
+        role-session-name: gha-${{ github.run_id }}
+        aws-region: ${{ inputs.aws-region }}
+        # The runner role grants sts:AssumeRole only (least privilege) — not
+        # sts:TagSession — so don't let the action add session tags.
+        role-skip-session-tagging: true
+
+    # Resolve the deployment path's account name to an id from the org itself.
+    - name: Resolve target account id
+      id: resolve
+      shell: bash
+      run: |
+        set -euo pipefail
+        id=$(aws organizations list-accounts \
+          --query "Accounts[?Name=='${{ inputs.account-name }}'].Id" \
+          --output text)
+        if [ -z "$id" ] || [ "$id" = "None" ]; then
+          echo "::error::no AWS Organizations account named '${{ inputs.account-name }}'"
+          exit 1
+        fi
+        echo "account-id=$id" >> "$GITHUB_OUTPUT"
+
+    # Hop 2: role-chain from the runner into the account's deploy role.
+    - name: Assume deploy role (chained)
+      uses: aws-actions/configure-aws-credentials@v5
+      with:
+        role-to-assume: >-
+          arn:aws:iam::${{ steps.resolve.outputs.account-id }}:role/${{ inputs.deploy-role-path }}
+        role-session-name: gha-deploy-${{ github.run_id }}
+        role-chaining: true
+        aws-region: ${{ inputs.aws-region }}
+        # The deploy role's trust grants sts:AssumeRole only — skip TagSession.
+        role-skip-session-tagging: true

--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -12,12 +12,27 @@ on:
 
 env:
   TG_WORKING_DIR: './deployments'
-  TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
+  # State key + provider tags read by terragrunt-common.hcl (matches the local
+  # Makefile's `basename $PWD`, so CI and local share one state path).
+  REPO_NAME: ${{ github.event.repository.name }}
+  # Hub trust model (see hansohn/aws-org-bootstrap): OIDC into this runner role,
+  # then chain into the target account's TerraformDeploymentRole. Set per repo
+  # as a repo variable (Settings > Secrets and variables > Actions > Variables)
+  # so the management account id stays out of source, e.g.
+  # arn:aws:iam::<account-id>:role/Org/TerraformRunnerRole
+  RUNNER_ROLE_ARN: ${{ vars.RUNNER_ROLE_ARN }}
+  # Org account = ORG_PREFIX + the deployments/<label>/ path segment.
+  # ORG_PREFIX is your AWS Organizations account-name prefix; set it per repo
+  # as a repo variable (Settings > Secrets and variables > Actions > Variables).
+  ORG_PREFIX: ${{ vars.ORG_PREFIX }}
+  ACCOUNT_LABEL: 'sandbox'
+  AWS_REGION: 'us-west-2'
 
-# Private repos need actions:read for the Slack status action to query the run.
+# id-token: OIDC exchange. actions:read: Slack status action queries the run.
 permissions:
   contents: read
   actions: read
+  id-token: write
 
 jobs:
   format:
@@ -47,77 +62,63 @@ jobs:
       - name: TFLint
         run: 'tflint --recursive'
 
-  # validate:
-  #   name: Validate
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: hansohn/terraform-aws:latest
-  #   needs: [ format ]
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
+  plan:
+    name: Plan
+    runs-on: ubuntu-latest
+    container:
+      image: hansohn/terraform-aws:latest
+    needs: [ format, lint ]
+    # Add an `env:` block here to wire any per-repo provider secrets.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
 
-  #     - name: Create Terraform Plugin Cache Dir
-  #       run: mkdir -p $TF_PLUGIN_CACHE_DIR
+      - name: Authenticate to AWS
+        uses: ./.github/actions/aws-auth
+        with:
+          runner-role-arn: ${{ env.RUNNER_ROLE_ARN }}
+          account-name: ${{ env.ORG_PREFIX }}${{ env.ACCOUNT_LABEL }}
+          aws-region: ${{ env.AWS_REGION }}
 
-  #     - name: Terraform Plugin Cache
-  #       uses: actions/cache@v4.0.1
-  #       with:
-  #         path: ${{ env.TF_PLUGIN_CACHE_DIR }}
-  #         key: ${{ runner.os }}-terraform-plugin-cache-${{ hashFiles('**/.terraform.lock.hcl') }}
+      # Terragrunt reads TG_WORKING_DIR from the env (it's the --working-dir
+      # flag), so don't also set the step's working-directory — that doubles
+      # the path to deployments/deployments.
+      - name: Plan
+        run: 'terragrunt run --all plan --non-interactive'
 
-  #     - name: Validate
-  #       run: 'terragrunt run --all validate -- -backend=false'
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    container:
+      image: hansohn/terraform-aws:latest
+    needs: [ plan ]
+    # Tag-as-approval: apply only when a version tag is pushed. Branch pushes
+    # stop at Plan; pushing `vX.Y.Z` is the deliberate act that rolls out.
+    if: startsWith(github.ref, 'refs/tags/')
+    concurrency:
+      group: deploy-${{ github.workflow }}
+      cancel-in-progress: false
+    # Add an `env:` block here to wire any per-repo provider secrets.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
 
-  # plan:
-  #   name: Plan
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: hansohn/terraform-aws:latest
-  #   needs: [ validate ]
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
+      - name: Authenticate to AWS
+        uses: ./.github/actions/aws-auth
+        with:
+          runner-role-arn: ${{ env.RUNNER_ROLE_ARN }}
+          account-name: ${{ env.ORG_PREFIX }}${{ env.ACCOUNT_LABEL }}
+          aws-region: ${{ env.AWS_REGION }}
 
-  #     - name: Create Terraform Plugin Cache Dir
-  #       run: mkdir -p $TF_PLUGIN_CACHE_DIR
-
-  #     - name: Terraform Plugin Cache
-  #       uses: actions/cache@v4.0.1
-  #       with:
-  #         path: ${{ env.TF_PLUGIN_CACHE_DIR }}
-  #         key: ${{ runner.os }}-terraform-plugin-cache-${{ hashFiles('**/.terraform.lock.hcl') }}
-
-  #     - name: Plan
-  #       run: 'terragrunt run --all plan'
-
-  # deploy:
-  #   name: Deploy
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: hansohn/terraform-aws:latest
-  #   needs: [ plan ]
-  #   if: github.ref == 'refs/heads/main'
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@main
-
-  #     - name: Create Terraform Plugin Cache Dir
-  #       run: mkdir -p $TF_PLUGIN_CACHE_DIR
-
-  #     - name: Terraform Plugin Cache
-  #       uses: actions/cache@v4.0.1
-  #       with:
-  #         path: ${{ env.TF_PLUGIN_CACHE_DIR }}
-  #         key: ${{ runner.os }}-terraform-plugin-cache-${{ hashFiles('**/.terraform.lock.hcl') }}
-
-  #     - name: Deploy
-  #       run: 'terragrunt run --all apply'
+      - name: Apply
+        run: 'terragrunt run --all apply --non-interactive'
 
   slack:
     name: Slack
     runs-on: ubuntu-latest
-    needs: [ format, lint ]
+    # deploy is skipped on branch pushes; always() runs slack regardless, and
+    # the status action reads the whole run — so tag runs report post-apply.
+    needs: [ format, lint, plan, deploy ]
     if: always()
     steps:
       - name: Checkout


### PR DESCRIPTION
Ports the CI deploy scaffolding from terragrunt-aws-minecraft into the template.

## What's added
- `.github/actions/aws-auth` composite action: OIDC into the hub `TerraformRunnerRole`, resolve the target account id from AWS Organizations by name, then role-chain into `TerraformDeploymentRole`.
- Real `plan` and `deploy` jobs replacing the commented-out placeholders; deploy gated on version tags (tag-as-approval) with a deploy concurrency group.
- `id-token: write` for the OIDC exchange; drop `TF_PLUGIN_CACHE_DIR` (breaks `hashFiles` in container jobs); `slack` reports post-apply.

Job graph: `format -> lint -> plan -> deploy`, with `slack` on all.

## Kept out of public source
- `RUNNER_ROLE_ARN` and `ORG_PREFIX` are sourced from repo variables (`vars.*`), so no real account id / org prefix lands in this public repo. Set them per repo under Settings > Secrets and variables > Actions > Variables.
- Per-repo provider secrets (e.g. a Cloudflare token) get wired via an `env:` block on plan/deploy — noted inline, not included.

## Note on validate
An earlier revision added a `validate` job, on the assumption it could run credential-free (`-backend=false`). It can't: `terragrunt-common.hcl` resolves the account id via `aws sts get-caller-identity` at parse time, so validate needs credentials just like plan. Adding auth to validate would only duplicate plan (which runs `terraform validate` implicitly), so the job was dropped.

## CI
Green on this branch: format / lint / plan pass; deploy skipped (not a tag).